### PR TITLE
fix: support yarn patches

### DIFF
--- a/src/tarballs/build.ts
+++ b/src/tarballs/build.ts
@@ -76,6 +76,8 @@ const copyCoreYarnFiles = async (yarnRootPath: string, workspacePath: string) =>
   await copyYarnDirectory('./.yarn/releases/', yarnRootPath, workspacePath)
   // copy yarn plugins if they exists
   await copyYarnDirectory('./.yarn/plugins/', yarnRootPath, workspacePath)
+  // copy yarn patches if they exists
+  await copyYarnDirectory('./.yarn/patches/', yarnRootPath, workspacePath)
 }
 
 type BuildOptions = {


### PR DESCRIPTION
If a library used by the CLI is being patches with `yarn patch`, building the CLI currently fails with:

```
    Error: Command failed: yarn workspaces focus --production

    Code: 1
```

This happens because the `.yarn/patches` directory is not copied to the `tmp` directory where the CLI is being built.

Fixing it by copying the directory if it exists (like it's done for other `.yarn/` directories)